### PR TITLE
Check if already authenticated in auth_from_File

### DIFF
--- a/tests/unit/test_vault_auth.py
+++ b/tests/unit/test_vault_auth.py
@@ -137,3 +137,25 @@ def test_auth_with_passthrough():
     """
     client = VaultAnyConfig()
     assert client.auth_from_file("config.json")
+
+
+@patch("vault_anyconfig.vault_anyconfig.load_base")
+@patch("vault_anyconfig.vault_anyconfig.Client.is_authenticated")
+def test_auth_with_already_authenticated(mock_is_authenticated, mock_load, gen_vault_creds, localhost_client):
+    """
+    Tests that the auth_from_file will simply be bypassed when the client is already authenticated
+    """
+    mock_load.return_value = gen_vault_creds()
+    mock_is_authenticated.return_value = True
+
+    assert localhost_client.auth_from_file("config.json")
+
+
+@patch("vault_anyconfig.vault_anyconfig.Client.is_authenticated")
+def test_auth_with_already_authenticated_and_passthrough(mock_is_authenticated):
+    """
+    Tests that the auth_from_file will simply be bypassed when using an instance with passthrough set and the client is already authenticated
+    """
+    mock_is_authenticated.return_value = True
+    client = VaultAnyConfig()
+    assert client.auth_from_file("config.json")

--- a/tests/unit/test_vault_auth.py
+++ b/tests/unit/test_vault_auth.py
@@ -45,9 +45,9 @@ def test_auth_from_file(
     Basic test for the auth_from_file function
     """
     mock_load.return_value = gen_vault_creds()
-    mock_is_authenticated.return_value = True
+    mock_is_authenticated.return_value = False
 
-    assert localhost_client.auth_from_file("config.json")
+    localhost_client.auth_from_file("config.json")
 
     compare_vault_creds = gen_vault_creds()
 
@@ -70,7 +70,7 @@ def test_auth_from_file_bad_method(
     local_vault_creds = gen_vault_creds()
     local_vault_creds["vault_creds"]["auth_method"] = "nothing"
     mock_load.return_value = local_vault_creds
-    mock_is_authenticated.return_value = True
+    mock_is_authenticated.return_value = False
 
     with pytest.raises(NotImplementedError):
         localhost_client.auth_from_file("config.json")

--- a/vault_anyconfig/vault_anyconfig.py
+++ b/vault_anyconfig/vault_anyconfig.py
@@ -56,7 +56,7 @@ class VaultAnyConfig(Client):
         Returns:
             bool of authenication status
         """
-        if self.pass_through_flag:
+        if self.pass_through_flag or self.is_authenticated():
             return True
 
         creds = load_base(vault_creds_file)["vault_creds"]
@@ -223,7 +223,8 @@ class VaultAnyConfig(Client):
                 secret_key = config_key_path[-1]
 
             read_vault_secret = self.read(secret_path)["data"][secret_key]
-            config_part = self.__get_nested_config(config_key_path, read_vault_secret)
+            config_part = self.__get_nested_config(
+                config_key_path, read_vault_secret)
             merge(vault_config_parts, config_part)
 
         return vault_config_parts
@@ -276,7 +277,8 @@ class VaultAnyConfig(Client):
         if len(path_list) == 1:
             config_part[path_list[0]] = value
         else:
-            config_part[path_list[0]] = self.__get_nested_config(path_list[1:], value)
+            config_part[path_list[0]] = self.__get_nested_config(
+                path_list[1:], value)
         return config_part
 
     def __get_value_nested_config(self, path_list, config):


### PR DESCRIPTION
Adding this check allows code consuming vault-anyconfig to call auth_from_file even if the client is already authenticated (for example if the token was provided in the vault configuration file).