### PR TITLE
Add ability to load from a token path in Kubernetes auth method

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0-dev
+current_version = 0.2.0-dev
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/vault_anyconfig/__init__.py
+++ b/vault_anyconfig/__init__.py
@@ -2,7 +2,7 @@
 
 """Top-level package for vault-anyconfig."""
 
-__version__ = "0.1.0-dev"
+__version__ = "0.2.0-dev"
 __project__ = "vault-anyconfig"
 __email__ = "eugene.davis@tomtom.com"
 __author__ = "Eugene Davis"


### PR DESCRIPTION
Add the ability to utilize a service account in Kubernetes when authenticating with Vault.