### PR TITLE
feat: Configs as strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ Currently vault-anyconfig **only** supports version 1 and 2 of the key value sto
 
 ## Files and Formatting
 
-There are three configuration files, which can be stored in one, two or three files total as long as they are correctly written.
+There are three configuration files (which can also be provided as strings), which can be stored in one, two or three files total as long as they are correctly written.
 
 Examples in this section will be in JSON, but any file format supported by anyconfig can be used.
 
-### Vault Configuration File
+### Vault Configuration
 
 This configures the connection to the Vault, and must contain at least one member (usually the url parameter). If this section is not provided or is
 left empty, then the Vault instance will **not** be configured, and instead only the anyconfig functionality will be used.
@@ -47,9 +47,9 @@ The section must be named `vault_config`, and can contain any of the parameters 
 }
 ```
 
-### Vault Authentication File
+### Vault Authentication
 
-This provides authentication for use with the `auth_from_file` method, and must be named `vault_creds`. It should contain a member named `auth_method`
+This provides authentication for use with the `auto_auth` method, and must be named `vault_creds`. It should contain a member named `auth_method`
 which should correspond with one of the auth method from [the HVAC Client](https://hvac.readthedocs.io/en/latest/usage/auth_methods/index.html) (without the "`auth_`" prefix), e.g. `approle`. The remaining members
 should match the parameters for the specified auth method.
 
@@ -65,9 +65,9 @@ should match the parameters for the specified auth method.
 }
 ```
 
-### Main Configuration File
+### Main Configuration
 
-The main configuration file should consist of the configuration sections you need **without** the secrets included (unless passthrough mode is desired)
+The main configuration should consist of the configuration sections you need **without** the secrets included (unless passthrough mode is desired)
 and a section named `vault_secrets`. In the `vault_secrets` section, the keys are dot separated paths for the keys to insert into your configuration,
 and the values are the path to the secret in Vault. Please see the `vault_secrets` usage section for the different ways to specify secrets.
 
@@ -226,9 +226,9 @@ VaultAnyconfig can be initalized in three ways (for two different modes):
 
 ### Authentication With Vault
 
-You can use `auth_from_file` by providing a file as explained in the files and formatting section, or you can directly use the auth methods from
-[the HVAC Client](https://hvac.readthedocs.io/en/latest/usage/auth_methods/index.html). If passthrough mode is set, `auth_from_file` will always return
-true, but the HVAC client methods will fail, so it is recommended to use `auth_from_file` where possible.
+You can use `auto_auth` by providing a file as explained in the files and formatting section, or you can directly use the auth methods from
+[the HVAC Client](https://hvac.readthedocs.io/en/latest/usage/auth_methods/index.html). If passthrough mode is set, `auto_auth` will always return
+true, but the HVAC client methods will fail, so it is recommended to use `auto_auth` where possible.
 
 #### Loading/Saving Files with Keys Inserted
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.3-dev
+current_version = 0.3.0-dev
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -47,7 +47,7 @@ def test_init_with_file(mock_hvac_client, mock_load, gen_vault_config):
     client = VaultAnyConfig(vault_config_in="config.json")
 
     assert not client.pass_through_flag
-    mock_load.assert_called_with("config.json")
+    mock_load.assert_called_with("config.json", False)
     mock_hvac_client.assert_called_with(url="http://localhost")
 
 
@@ -68,7 +68,7 @@ def test_init_passthrough(mock_load, gen_vault_config):
 
     client = VaultAnyConfig(vault_config_in="test\n")
     assert client.pass_through_flag
-    mock_load.assert_called_with("test\n")
+    mock_load.assert_called_with("test\n", False)
 
 
 @patch("vault_anyconfig.vault_anyconfig.loads_base")
@@ -80,7 +80,7 @@ def test_init_passthrough_no_vault_config_section(mock_load):
 
     client = VaultAnyConfig(vault_config_in="test:\n")
     assert client.pass_through_flag
-    mock_load.assert_called_with("test:\n")
+    mock_load.assert_called_with("test:\n", False)
 
 
 @patch("vault_anyconfig.vault_anyconfig.isfile")
@@ -94,4 +94,16 @@ def test_init_passthrough_file(mock_load, mock_isfile):
 
     client = VaultAnyConfig(vault_config_in="config.json")
     assert client.pass_through_flag
-    mock_load.assert_called_with("config.json")
+    mock_load.assert_called_with("config.json", False)
+
+
+@patch("vault_anyconfig.vault_anyconfig.loads_base")
+def test_init_passthrough_test_both_vault_config_in_and_vault_config_file(mock_load):
+    """
+    Tests that with a vault configuration in which both the vault_config_in and vault_config_file are set the vault_config_in parameter takes precedence.
+    """
+    mock_load.return_value = {}
+
+    client = VaultAnyConfig(vault_config_in="test:\n", vault_config_file="config.json")
+    assert client.pass_through_flag
+    mock_load.assert_called_with("test:\n", False)

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -36,7 +36,7 @@ def test_init_no_file(mock_hvac_client):
     mock_hvac_client.assert_called_with(url="http://localhost")
 
 
-@patch("vault_anyconfig.vault_anyconfig.load_base")
+@patch("vault_anyconfig.vault_anyconfig.loads_base")
 @patch("vault_anyconfig.vault_anyconfig.Client.__init__")
 def test_init_with_file(mock_hvac_client, mock_load, gen_vault_config):
     """
@@ -44,7 +44,7 @@ def test_init_with_file(mock_hvac_client, mock_load, gen_vault_config):
     """
     mock_load.return_value = gen_vault_config()
 
-    client = VaultAnyConfig(vault_config_file="config.json")
+    client = VaultAnyConfig(vault_config_in="config.json")
 
     assert not client.pass_through_flag
     mock_load.assert_called_with("config.json")
@@ -59,25 +59,39 @@ def test_init_passthrough_args(gen_vault_config):
     assert client.pass_through_flag
 
 
-@patch("vault_anyconfig.vault_anyconfig.load_base")
-def test_init_passthrough_file(mock_load, gen_vault_config):
+@patch("vault_anyconfig.vault_anyconfig.loads_base")
+def test_init_passthrough(mock_load, gen_vault_config):
     """
-    Tests that with a vault configuration file where the vault_config section is empty, the passthrough flag is set
+    Tests that with a vault configuration where the vault_config section is empty, the passthrough flag is set
     """
     mock_load.return_value = gen_vault_config(empty=True)
 
-    client = VaultAnyConfig(vault_config_file="config.json")
+    client = VaultAnyConfig(vault_config_in="test\n")
     assert client.pass_through_flag
-    mock_load.assert_called_with("config.json")
+    mock_load.assert_called_with("test\n")
 
 
-@patch("vault_anyconfig.vault_anyconfig.load_base")
-def test_init_passthrough_file_no_vault_config_section(mock_load):
+@patch("vault_anyconfig.vault_anyconfig.loads_base")
+def test_init_passthrough_no_vault_config_section(mock_load):
     """
-    Tests that with a vault configuration file where there is no vault_config section, the passthrough flag is set
+    Tests that with a vault configuration where there is no vault_config section, the passthrough flag is set
     """
     mock_load.return_value = {}
 
-    client = VaultAnyConfig(vault_config_file="config.json")
+    client = VaultAnyConfig(vault_config_in="test:\n")
+    assert client.pass_through_flag
+    mock_load.assert_called_with("test:\n")
+
+
+@patch("vault_anyconfig.vault_anyconfig.isfile")
+@patch("vault_anyconfig.vault_anyconfig.load_base")
+def test_init_passthrough_file(mock_load, mock_isfile):
+    """
+    Tests that with a vault configuration file where there is no vault_config section, the passthrough flag is set
+    """
+    mock_isfile.return_value = True
+    mock_load.return_value = {}
+
+    client = VaultAnyConfig(vault_config_in="config.json")
     assert client.pass_through_flag
     mock_load.assert_called_with("config.json")

--- a/vault_anyconfig/__init__.py
+++ b/vault_anyconfig/__init__.py
@@ -2,7 +2,7 @@
 
 """Top-level package for vault-anyconfig."""
 
-__version__ = "0.2.3-dev"
+__version__ = "0.3.0-dev"
 __project__ = "vault-anyconfig"
 __email__ = "eugene.davis@tomtom.com"
 __author__ = "Eugene Davis"

--- a/vault_anyconfig/cli.py
+++ b/vault_anyconfig/cli.py
@@ -33,7 +33,7 @@ def main():
     """
     args = parse_args(sys.argv[1:])
 
-    client = VaultAnyConfig(vault_config_file=args.vault_config)
+    client = VaultAnyConfig(vault_config_in=args.vault_config)
     client.auth_from_file(args.vault_creds)
 
     config = client.load(args.in_file, process_secret_files=args.secret_files_write, ac_parser=args.file_type)

--- a/vault_anyconfig/cli.py
+++ b/vault_anyconfig/cli.py
@@ -34,7 +34,7 @@ def main():
     args = parse_args(sys.argv[1:])
 
     client = VaultAnyConfig(vault_config_in=args.vault_config)
-    client.auth_from_file(args.vault_creds)
+    client.auto_auth(args.vault_creds)
 
     config = client.load(args.in_file, process_secret_files=args.secret_files_write, ac_parser=args.file_type)
 

--- a/vault_anyconfig/cli.py
+++ b/vault_anyconfig/cli.py
@@ -17,8 +17,10 @@ def parse_args(args):
     parser.add_argument("in_file", type=argparse.FileType("r"), help="Configuration file to read in")
     parser.add_argument("out_file", type=argparse.FileType("w"), help="File to write out after populating")
     parser.add_argument("--file_type", type=str, required=True, help="File type to read and write")
-    parser.add_argument("--vault_config", type=str, required=True, help="Vault configuration file.")
-    parser.add_argument("--vault_creds", type=str, required=True, help="Vault credentials file")
+    parser.add_argument(
+        "--vault_config", type=str, required=True, help="Vault configuration file  as string or file path."
+    )
+    parser.add_argument("--vault_creds", type=str, required=True, help="Vault credentials as string or file path")
     parser.add_argument(
         "--secret_files_write",
         action="store_false",

--- a/vault_anyconfig/cli.py
+++ b/vault_anyconfig/cli.py
@@ -18,7 +18,7 @@ def parse_args(args):
     parser.add_argument("out_file", type=argparse.FileType("w"), help="File to write out after populating")
     parser.add_argument("--file_type", type=str, required=True, help="File type to read and write")
     parser.add_argument(
-        "--vault_config", type=str, required=True, help="Vault configuration file  as string or file path."
+        "--vault_config", type=str, required=True, help="Vault configuration file as string or file path."
     )
     parser.add_argument("--vault_creds", type=str, required=True, help="Vault credentials as string or file path")
     parser.add_argument(

--- a/vault_anyconfig/vault_anyconfig.py
+++ b/vault_anyconfig/vault_anyconfig.py
@@ -15,7 +15,7 @@ class VaultAnyConfig(Client):
     Extends the HVAC Hashicorp Vault client to be able to read/write configuration files and update them with information from a Vault instance.
     """
 
-    def __init__(self, vault_config_file=None, **args):
+    def __init__(self, vault_config_in=None, vault_config_file=None, **args):
         """
         Creates a connection to Vault with either the arguments normally provided to an HVAC client instance, or a configuration file containing them.
         See https://github.com/hvac/hvac/blob/master/hvac/v1/__init__.py for detailed list of arguments available.
@@ -23,15 +23,18 @@ class VaultAnyConfig(Client):
         used on the HVAC Client's init function.
 
         Args:
-            - vault_config_file: [Optional] file[path] to a configuration file with Vault configuration arguments
+            - vault_config_in: [Optional] file[path] to a configuration file or string with Vault configuration arguments
+            - vault_config_in: [Deprecated] file[path] to a configuration file with Vault configuration arguments
             - args: [Optional] Arguments for an HVAC client, typically it will need at least url
         """
         self.pass_through_flag = False
 
-        if not vault_config_file:
+        if not vault_config_in and not vault_config_file:
             vault_config = args
+        elif isfile(vault_config_in) or vault_config_file is not None:
+            vault_config = load_base(vault_config_in).get("vault_config", {})
         else:
-            vault_config = load_base(vault_config_file).get("vault_config", {})
+            vault_config = loads_base(vault_config_in).get("vault_config", {})
 
         if vault_config:
             super().__init__(**vault_config)

--- a/vault_anyconfig/vault_anyconfig.py
+++ b/vault_anyconfig/vault_anyconfig.py
@@ -52,7 +52,18 @@ class VaultAnyConfig(Client):
         else:
             self.pass_through_flag = True
 
-    def auth_from_file(self, vault_creds=None, vault_creds_file=None):
+    def auth_from_file(self, vault_creds_file=None):
+        """
+        Deprecated function, has been replaced with auto_auth. Currently will work as a passthrough to auto_auth.
+        """
+        warn(
+            "The auth_from_file method is deprecated and has been replaced with auto_auth. It will be removed in a future release.",
+            DeprecationWarning,
+        )
+
+        return self.auto_auth(vault_creds_file)
+
+    def auto_auth(self, vault_creds=None):
         """
         Invokes the specified Vault authentication method and provides credentials to it from a configuration file
         See https://hvac.readthedocs.io/en/latest/usage/auth_methods/index.html for a list of HVAC auth methods.
@@ -65,22 +76,11 @@ class VaultAnyConfig(Client):
                 https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#service-account-admission-controller
 
         Args:
+            - vault_creds_file: string or file path with the credentials for the Vault
             - vault_creds_file: file containing the credentials for the Vault
         Returns:
             bool of authenication status
         """
-        # Deprecation warning for vault_creds_file
-        warn(
-            "The vault_creds_file parameter is deprecated and will be removed in a feature release.", DeprecationWarning
-        )
-
-        if vault_creds_file and vault_creds:
-            warn(
-                "Both vault_creds and vault_creds_file are set. Only vault_creds will be used, all usage of vault_creds_file should be removed",
-                UserWarning,
-            )
-        vault_creds = vault_creds if vault_creds else vault_creds_file
-
         if self.pass_through_flag or self.is_authenticated():
             return True
 

--- a/vault_anyconfig/vault_anyconfig.py
+++ b/vault_anyconfig/vault_anyconfig.py
@@ -24,10 +24,16 @@ class VaultAnyConfig(Client):
 
         Args:
             - vault_config_in: [Optional] file[path] to a configuration file or string with Vault configuration arguments
-            - vault_config_in: [Deprecated] file[path] to a configuration file with Vault configuration arguments
+            - vault_config_file: [Deprecated] file[path] to a configuration file with Vault configuration arguments
             - args: [Optional] Arguments for an HVAC client, typically it will need at least url
         """
         self.pass_through_flag = False
+
+        # Deprecation warning for vault_config_file
+        warn(
+            "The vault_config_file parameter is deprecated and will be removed in a feature release.",
+            DeprecationWarning,
+        )
 
         if not vault_config_in and not vault_config_file:
             vault_config = args

--- a/vault_anyconfig/vault_anyconfig.py
+++ b/vault_anyconfig/vault_anyconfig.py
@@ -52,7 +52,7 @@ class VaultAnyConfig(Client):
         else:
             self.pass_through_flag = True
 
-    def auth_from_file(self, vault_creds_file):
+    def auth_from_file(self, vault_creds=None, vault_creds_file=None):
         """
         Invokes the specified Vault authentication method and provides credentials to it from a configuration file
         See https://hvac.readthedocs.io/en/latest/usage/auth_methods/index.html for a list of HVAC auth methods.
@@ -69,10 +69,22 @@ class VaultAnyConfig(Client):
         Returns:
             bool of authenication status
         """
+        # Deprecation warning for vault_creds_file
+        warn(
+            "The vault_creds_file parameter is deprecated and will be removed in a feature release.", DeprecationWarning
+        )
+
+        if vault_creds_file and vault_creds:
+            warn(
+                "Both vault_creds and vault_creds_file are set. Only vault_creds will be used, all usage of vault_creds_file should be removed",
+                UserWarning,
+            )
+        vault_creds = vault_creds if vault_creds else vault_creds_file
+
         if self.pass_through_flag or self.is_authenticated():
             return True
 
-        creds = load_base(vault_creds_file)["vault_creds"]
+        creds = self._smart_load(vault_creds)["vault_creds"]
         auth_method = "auth_" + creds["auth_method"]
         creds.pop("auth_method", None)
 


### PR DESCRIPTION
Introduces the ability to configure from strings rather than just files, to allow supporting use in serverless environments.

Adds a bit of awkwardness in the short term to keep backwards compatability on parameter names and `auth_from_file`, but these are marked as deprecated and will be removed fully in the future.