### PR TITLE
fix: Allow providing the ac_parser option

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ test = pytest
 
 [tool:pytest]
 addopts = -s -vv --cov-report xml:build/coverage.xml --cov-report term --cov-branch --cov vault_anyconfig --junitxml=build/test_results.xml --black
-testpaths = tests/unit vault_anyconfig
+testpaths = tests vault_anyconfig
 collect_ignore = ['setup.py']
 
 [coverage:report]

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("README.md") as readme_file:
 with open("CHANGELOG.md") as changelog_file:
     changelog = changelog_file.read()
 
-requirements = ["anyconfig==0.9.8", "hvac==0.7.2"]
+requirements = ["anyconfig==0.9.9", "hvac==0.7.2"]
 
 setup_requirements = ["pytest-runner"]
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ requirements = ["anyconfig==0.9.8", "hvac==0.7.2"]
 
 setup_requirements = ["pytest-runner"]
 
-test_requirements = ["pytest", "pytest-cov", "coverage", "hypothesis"]
+test_requirements = ["pytest", "pytest-cov", "coverage", "hypothesis", "pyaml"]
 
 setup(
     author=vault_anyconfig.__author__,

--- a/tests/integration/test_anyconfig.py
+++ b/tests/integration/test_anyconfig.py
@@ -16,7 +16,7 @@ PARSER_PARAMS = {"arg_names": "parser_dump_function,parser_name", "params": [(js
 @patch("vault_anyconfig.vault_anyconfig.Client.__init__")
 def test_init_string(mock_hvac, parser_dump_function, parser_name):
     """
-    Ensures that a json configuration string will be correctly read
+    Tests that using a string to initialize the client will work
     """
     test_config = {"vault_config": {"test_value": 1, "test_value2": "value2"}, "extra_stuff": "test_me"}
     VaultAnyConfig(vault_config_in=parser_dump_function(test_config), ac_parser=parser_name)
@@ -28,7 +28,7 @@ def test_init_string(mock_hvac, parser_dump_function, parser_name):
 @patch("vault_anyconfig.vault_anyconfig.Client.auth_approle")
 def test_auto_auth(mock_auth_approle, mock_is_authenticated, parser_dump_function, parser_name):
     """
-    Basic test for the auto_auth function
+    Tests that string inputs to auto_auth will be correctly parsed
     """
     creds = {"vault_creds": {"auth_method": "approle", "role_id": "test_jim_bob", "secret_id": "test_123password"}}
     mock_is_authenticated.return_value = False

--- a/tests/integration/test_anyconfig.py
+++ b/tests/integration/test_anyconfig.py
@@ -1,0 +1,41 @@
+"""
+Integration tests with anyconfig
+"""
+import json
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from vault_anyconfig.vault_anyconfig import VaultAnyConfig
+
+PARSER_PARAMS = {"arg_names": "parser_dump_function,parser_name", "params": [(json.dumps, "json"), (yaml.dump, "yaml")]}
+
+
+@pytest.mark.parametrize(PARSER_PARAMS["arg_names"], PARSER_PARAMS["params"])
+@patch("vault_anyconfig.vault_anyconfig.Client.__init__")
+def test_init_string(mock_hvac, parser_dump_function, parser_name):
+    """
+    Ensures that a json configuration string will be correctly read
+    """
+    test_config = {"vault_config": {"test_value": 1, "test_value2": "value2"}, "extra_stuff": "test_me"}
+    VaultAnyConfig(vault_config_in=parser_dump_function(test_config), ac_parser=parser_name)
+    mock_hvac.assert_called_once_with(test_value=1, test_value2="value2")
+
+
+@pytest.mark.parametrize(PARSER_PARAMS["arg_names"], PARSER_PARAMS["params"])
+@patch("vault_anyconfig.vault_anyconfig.Client.is_authenticated")
+@patch("vault_anyconfig.vault_anyconfig.Client.auth_approle")
+def test_auto_auth(mock_auth_approle, mock_is_authenticated, parser_dump_function, parser_name):
+    """
+    Basic test for the auto_auth function
+    """
+    creds = {"vault_creds": {"auth_method": "approle", "role_id": "test_jim_bob", "secret_id": "test_123password"}}
+    mock_is_authenticated.return_value = False
+
+    VaultAnyConfig(url="http://localhost").auto_auth(parser_dump_function(creds), ac_parser=parser_name)
+
+    mock_auth_approle.assert_called_with(
+        role_id=creds["vault_creds"]["role_id"], secret_id=creds["vault_creds"]["secret_id"]
+    )
+    mock_is_authenticated.assert_called_with()

--- a/tests/integration/test_anyconfig.py
+++ b/tests/integration/test_anyconfig.py
@@ -5,11 +5,14 @@ import json
 from unittest.mock import patch
 
 import pytest
-import yaml
+import pyaml
 
 from vault_anyconfig.vault_anyconfig import VaultAnyConfig
 
-PARSER_PARAMS = {"arg_names": "parser_dump_function,parser_name", "params": [(json.dumps, "json"), (yaml.dump, "yaml")]}
+PARSER_PARAMS = {
+    "arg_names": "parser_dump_function,parser_name",
+    "params": [(json.dumps, "json"), (pyaml.dump, "yaml")],
+}
 
 
 @pytest.mark.parametrize(PARSER_PARAMS["arg_names"], PARSER_PARAMS["params"])

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -44,10 +44,10 @@ def test_init_with_file(mock_hvac_client, mock_load, gen_vault_config):
     """
     mock_load.return_value = gen_vault_config()
 
-    client = VaultAnyConfig(vault_config_in="config.json")
+    client = VaultAnyConfig(vault_config_in="config.json", ac_parser="test_parser")
 
     assert not client.pass_through_flag
-    mock_load.assert_called_with("config.json", False)
+    mock_load.assert_called_with("config.json", ac_parser="test_parser")
     mock_hvac_client.assert_called_with(url="http://localhost")
 
 
@@ -66,9 +66,9 @@ def test_init_passthrough(mock_load, gen_vault_config):
     """
     mock_load.return_value = gen_vault_config(empty=True)
 
-    client = VaultAnyConfig(vault_config_in="test\n")
+    client = VaultAnyConfig(vault_config_in="test\n", ac_parser="test_parser")
     assert client.pass_through_flag
-    mock_load.assert_called_with("test\n", False)
+    mock_load.assert_called_with("test\n", ac_parser="test_parser")
 
 
 @patch("vault_anyconfig.vault_anyconfig.loads_base")
@@ -78,9 +78,9 @@ def test_init_passthrough_no_vault_config_section(mock_load):
     """
     mock_load.return_value = {}
 
-    client = VaultAnyConfig(vault_config_in="test:\n")
+    client = VaultAnyConfig(vault_config_in="test:\n", ac_parser="test_parser")
     assert client.pass_through_flag
-    mock_load.assert_called_with("test:\n", False)
+    mock_load.assert_called_with("test:\n", ac_parser="test_parser")
 
 
 @patch("vault_anyconfig.vault_anyconfig.isfile")
@@ -94,7 +94,7 @@ def test_init_passthrough_file(mock_load, mock_isfile):
 
     client = VaultAnyConfig(vault_config_in="config.json")
     assert client.pass_through_flag
-    mock_load.assert_called_with("config.json", False)
+    mock_load.assert_called_with("config.json", ac_parser=None)
 
 
 @patch("vault_anyconfig.vault_anyconfig.loads_base")
@@ -104,6 +104,6 @@ def test_init_passthrough_test_both_vault_config_in_and_vault_config_file(mock_l
     """
     mock_load.return_value = {}
 
-    client = VaultAnyConfig(vault_config_in="test:\n", vault_config_file="config.json")
+    client = VaultAnyConfig(vault_config_in="test:\n", vault_config_file="config.json", ac_parser="test_parser")
     assert client.pass_through_flag
-    mock_load.assert_called_with("test:\n", False)
+    mock_load.assert_called_with("test:\n", ac_parser="test_parser")

--- a/tests/unit/test_vault_auth.py
+++ b/tests/unit/test_vault_auth.py
@@ -37,11 +37,11 @@ def test_auto_auth(mock_load, mock_auth_approle, mock_is_authenticated, localhos
     mock_load.return_value = gen_vault_creds()
     mock_is_authenticated.return_value = False
 
-    localhost_client.auto_auth("config.json")
+    localhost_client.auto_auth("config.json", ac_parser="test_parser")
 
     compare_vault_creds = gen_vault_creds()
 
-    mock_load.assert_called_with("config.json", False)
+    mock_load.assert_called_with("config.json", ac_parser="test_parser")
     mock_auth_approle.assert_called_with(
         role_id=compare_vault_creds["vault_creds"]["role_id"], secret_id=compare_vault_creds["vault_creds"]["secret_id"]
     )
@@ -60,17 +60,15 @@ def test_auto_auth_bad_method(mock_load, mock_is_authenticated, localhost_client
     mock_is_authenticated.return_value = False
 
     with pytest.raises(NotImplementedError):
-        localhost_client.auto_auth("config.json")
+        localhost_client.auto_auth("config.json", ac_parser="test_parser")
 
-    mock_load.assert_called_with("config.json", False)
+    mock_load.assert_called_with("config.json", ac_parser="test_parser")
 
 
 @patch("vault_anyconfig.vault_anyconfig.Client.auth_kubernetes")
 @patch("vault_anyconfig.vault_anyconfig.Client.is_authenticated")
 @patch("vault_anyconfig.vault_anyconfig.loads_base")
-def test_auto_auth_k8s_method(
-    mock_load, mock_is_authenticated, mock_auth_kubernetes, localhost_client, gen_vault_creds
-):
+def test_auto_auth_k8s_method(mock_load, mock_is_authenticated, mock_auth_kubernetes, localhost_client):
     """
     Test that the kubernetes method *without* the token path configured is called directly
     """
@@ -78,9 +76,9 @@ def test_auto_auth_k8s_method(
     mock_load.return_value = local_vault_creds
     mock_is_authenticated.return_value = False
 
-    localhost_client.auto_auth("config.json")
+    localhost_client.auto_auth("config.json", ac_parser="test_parser")
 
-    mock_load.assert_called_with("config.json", False)
+    mock_load.assert_called_with("config.json", ac_parser="test_parser")
     mock_auth_kubernetes.assert_called_with(role="test_role", jwt="jwt_string")
 
 
@@ -89,7 +87,7 @@ def test_auto_auth_k8s_method(
 @patch("vault_anyconfig.vault_anyconfig.Client.is_authenticated")
 @patch("vault_anyconfig.vault_anyconfig.load_base")
 def test_auto_auth_k8s_method_token_path(
-    mock_load, mock_is_authenticated, mock_auth_kubernetes, mock_isfile, localhost_client, gen_vault_creds
+    mock_load, mock_is_authenticated, mock_auth_kubernetes, mock_isfile, localhost_client
 ):
     """
     Test that the kubernetes method *with* the token path configured is called with the value from the token file
@@ -109,7 +107,7 @@ def test_auto_auth_k8s_method_token_path(
         localhost_client.auto_auth("config.json")
         mock_open_handle.assert_called_once_with("/var/run/secrets/kubernetes.io/serviceaccount", "r")
 
-    mock_load.assert_called_with("config.json", False)
+    mock_load.assert_called_with("config.json", ac_parser=None)
     mock_auth_kubernetes.assert_called_with(role="test_role", jwt="jwt_string")
 
 
@@ -150,4 +148,4 @@ def test_auth_from_file(mock_auto_auth):
     """
     client = VaultAnyConfig()
     client.auth_from_file("test.json")
-    mock_auto_auth.assert_called_once_with("test.json")
+    mock_auto_auth.assert_called_once_with("test.json", ac_parser=None)


### PR DESCRIPTION
The ac_parser option must be available when loading from strings (it is autodetected when loading from files).

Added some integration tests to cover this case.

Includes an update to the any-config version to allow tests to allow Windows and MacOS tests environments to pass the YAML integration tests.